### PR TITLE
Add package main entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
 
 ```bash
 poetry install
+# Запустить бот можно так:
 poetry run python -m bot
+# либо явно указать модуль main
+poetry run python -m bot.main
 ```
 
 Не забудьте указать переменные окружения `BOT_TOKEN` и `ADMIN_ID`.

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,0 +1,5 @@
+import asyncio
+from .main import main
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- run bot with `python -m bot`
- document both entrypoints in README

## Testing
- `poetry run python -m bot.main` *(fails: TokenValidationError)*
- `poetry run python -m bot` *(fails: TokenValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_686eaeae01dc8328982c85ad4d0bcb91