### PR TITLE
Add Bot default properties for aiogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
 
 ```bash
 poetry install
+# Запустить бот можно так:
 poetry run python -m bot
+# либо явно указать модуль main
+poetry run python -m bot.main
 ```
 
 Не забудьте указать переменные окружения `BOT_TOKEN` и `ADMIN_ID`.

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,0 +1,5 @@
+import asyncio
+from .main import main
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bot/db/dao.py
+++ b/bot/db/dao.py
@@ -17,6 +17,25 @@ class Database:
                         description TEXT
                     )"""
             )
+            self.conn.execute(
+                """CREATE TABLE IF NOT EXISTS users (
+                        user_id INTEGER PRIMARY KEY,
+                        username TEXT
+                    )"""
+            )
+            self.conn.execute(
+                """CREATE TABLE IF NOT EXISTS services (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        name TEXT
+                    )"""
+            )
+            self.conn.execute(
+                """CREATE TABLE IF NOT EXISTS examples (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        file_id TEXT,
+                        caption TEXT
+                    )"""
+            )
 
     def add_request(self, user_id: int, username: str, service: str, description: str) -> None:
         with self.conn:
@@ -28,3 +47,50 @@ class Database:
     def get_requests(self) -> List[Tuple]:
         with self.conn:
             return self.conn.execute("SELECT id, user_id, username, service, description FROM requests").fetchall()
+
+    def add_user(self, user_id: int, username: str) -> None:
+        with self.conn:
+            self.conn.execute(
+                "INSERT INTO users (user_id, username) VALUES (?, ?) ON CONFLICT(user_id) DO UPDATE SET username=excluded.username",
+                (user_id, username),
+            )
+
+    def get_users(self) -> List[Tuple]:
+        with self.conn:
+            return self.conn.execute("SELECT user_id FROM users").fetchall()
+
+    def add_example(self, file_id: str, caption: str) -> None:
+        with self.conn:
+            self.conn.execute(
+                "INSERT INTO examples (file_id, caption) VALUES (?, ?)",
+                (file_id, caption),
+            )
+
+    def update_example(self, example_id: int, caption: str) -> None:
+        with self.conn:
+            self.conn.execute(
+                "UPDATE examples SET caption=? WHERE id=?",
+                (caption, example_id),
+            )
+
+    def get_examples(self) -> List[Tuple]:
+        with self.conn:
+            return self.conn.execute("SELECT id, file_id, caption FROM examples").fetchall()
+
+    def add_service(self, name: str) -> None:
+        with self.conn:
+            self.conn.execute(
+                "INSERT INTO services (name) VALUES (?)",
+                (name,),
+            )
+
+    def update_service(self, service_id: int, name: str) -> None:
+        with self.conn:
+            self.conn.execute(
+                "UPDATE services SET name=? WHERE id=?",
+                (name, service_id),
+            )
+
+    def get_services(self) -> List[Tuple]:
+        with self.conn:
+            return self.conn.execute("SELECT id, name FROM services").fetchall()

--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -2,17 +2,38 @@ from aiogram import Router, types
 from aiogram import F
 from ..db.dao import Database
 from ..config import settings
-from ..keyboards.common import admin_menu, main_menu
+from ..keyboards.common import admin_menu, main_menu, cancel_kb, back_kb
+from aiogram.fsm.context import FSMContext
+from ..states.forms import ExampleForm, ServiceForm, NewsForm
 
 router = Router()
 
 db = Database(settings.db_path)
+
+
+@router.message(ExampleForm.file, F.text == "Отмена")
+@router.message(ExampleForm.caption, F.text == "Отмена")
+@router.message(ServiceForm.name, F.text == "Отмена")
+@router.message(NewsForm.text, F.text == "Отмена")
+async def cancel_state(msg: types.Message, state: FSMContext):
+    if msg.from_user.id != settings.admin_id:
+        return
+    await state.clear()
+    await msg.answer("Действие отменено", reply_markup=admin_menu)
 
 @router.message(F.text == "admin")
 async def admin_start(msg: types.Message):
     if msg.from_user.id != settings.admin_id:
         return
     await msg.answer("Админ меню", reply_markup=admin_menu)
+
+
+@router.message(F.text == "Назад")
+async def admin_back(msg: types.Message, state: FSMContext):
+    if msg.from_user.id != settings.admin_id:
+        return
+    await state.clear()
+    await msg.answer("Главное меню", reply_markup=main_menu)
 
 @router.message(F.text == "Список заявок")
 async def list_requests(msg: types.Message):
@@ -25,8 +46,60 @@ async def list_requests(msg: types.Message):
     text = "\n".join(f"#{e[0]} | {e[2]} | {e[3]}\n{e[4]}" for e in entries)
     await msg.answer(text, reply_markup=admin_menu)
 
-@router.message(F.text == "Добавить пример работы")
-async def add_example(msg: types.Message):
+
+@router.message(F.text == "Добавить услугу")
+async def add_service(msg: types.Message, state: FSMContext):
     if msg.from_user.id != settings.admin_id:
         return
-    await msg.answer("Отправьте картинку или видео, которое хотите добавить в highlights")
+    await state.set_state(ServiceForm.name)
+    await msg.answer("Название услуги", reply_markup=cancel_kb)
+
+
+@router.message(ServiceForm.name)
+async def service_name(msg: types.Message, state: FSMContext):
+    db.add_service(msg.text)
+    await state.clear()
+    await msg.answer("Услуга добавлена", reply_markup=admin_menu)
+
+
+@router.message(F.text == "Рассылка новости")
+async def start_news(msg: types.Message, state: FSMContext):
+    if msg.from_user.id != settings.admin_id:
+        return
+    await state.set_state(NewsForm.text)
+    await msg.answer("Введите текст рассылки", reply_markup=cancel_kb)
+
+
+@router.message(NewsForm.text)
+async def send_news(msg: types.Message, state: FSMContext):
+    users = db.get_users()
+    for user_id, in users:
+        try:
+            await msg.bot.send_message(user_id, msg.text)
+        except Exception:
+            pass
+    await state.clear()
+    await msg.answer("Рассылка завершена", reply_markup=admin_menu)
+
+@router.message(F.text == "Добавить пример работы")
+async def add_example(msg: types.Message, state: FSMContext):
+    if msg.from_user.id != settings.admin_id:
+        return
+    await state.set_state(ExampleForm.file)
+    await msg.answer("Отправьте картинку или видео", reply_markup=cancel_kb)
+
+
+@router.message(ExampleForm.file, F.photo | F.video)
+async def example_file(msg: types.Message, state: FSMContext):
+    file_id = msg.photo[-1].file_id if msg.photo else msg.video.file_id
+    await state.update_data(file_id=file_id)
+    await state.set_state(ExampleForm.caption)
+    await msg.answer("Добавьте подпись", reply_markup=cancel_kb)
+
+
+@router.message(ExampleForm.caption, F.text)
+async def example_caption(msg: types.Message, state: FSMContext):
+    data = await state.get_data()
+    db.add_example(data["file_id"], msg.text)
+    await state.clear()
+    await msg.answer("Пример добавлен", reply_markup=admin_menu)

--- a/bot/handlers/user.py
+++ b/bot/handlers/user.py
@@ -13,12 +13,29 @@ db = Database(settings.db_path)
 
 @router.message(CommandStart())
 async def start(msg: types.Message):
+    db.add_user(msg.from_user.id, msg.from_user.username or "")
     text = (
         "\U0001F7E2 Стартовое сообщение:  Привет!  Я — DaniAi 2.0: создаю AI-визуал, стиль и Reels, собранные из нейросетей."\
         "  Ниже можешь посмотреть мои работы и выбрать, как связаться \U0001F447"\
         "\n\n\U0001F4F8 Здесь можно вставить примеры работ — «Highlights»: картинки, видео"
     )
     await msg.answer(text, reply_markup=main_menu)
+
+
+@router.message(F.text == "Мои услуги")
+async def my_services(msg: types.Message):
+    services = db.get_services()
+    if not services:
+        await msg.answer("Пока нет услуг", reply_markup=back_kb)
+        return
+    text = "\n".join(f"• {s[1]}" for s in services)
+    await msg.answer(text, reply_markup=back_kb)
+
+
+@router.message(F.text == "Назад")
+async def back_to_menu(msg: types.Message, state: FSMContext):
+    await state.clear()
+    await msg.answer("Главное меню", reply_markup=main_menu)
 
 @router.message(F.text == "Заполнить анкету")
 async def fill_form(msg: types.Message, state: FSMContext):

--- a/bot/keyboards/common.py
+++ b/bot/keyboards/common.py
@@ -1,9 +1,13 @@
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton, InlineKeyboardMarkup, InlineKeyboardButton
 
-main_menu = ReplyKeyboardMarkup(keyboard=[
-    [KeyboardButton(text="Заполнить анкету")],
-    [KeyboardButton(text="Написать напрямую DaniAi")]
-], resize_keyboard=True)
+main_menu = ReplyKeyboardMarkup(
+    keyboard=[
+        [KeyboardButton(text="Заполнить анкету")],
+        [KeyboardButton(text="Мои услуги")],
+        [KeyboardButton(text="Написать напрямую DaniAi")],
+    ],
+    resize_keyboard=True,
+)
 
 cancel_kb = ReplyKeyboardMarkup(keyboard=[
     [KeyboardButton(text="Отмена")]
@@ -13,7 +17,13 @@ back_kb = ReplyKeyboardMarkup(keyboard=[
     [KeyboardButton(text="Назад")]
 ], resize_keyboard=True)
 
-admin_menu = ReplyKeyboardMarkup(keyboard=[
-    [KeyboardButton(text="Список заявок")],
-    [KeyboardButton(text="Добавить пример работы")]
-], resize_keyboard=True)
+admin_menu = ReplyKeyboardMarkup(
+    keyboard=[
+        [KeyboardButton(text="Список заявок")],
+        [KeyboardButton(text="Добавить пример работы")],
+        [KeyboardButton(text="Добавить услугу")],
+        [KeyboardButton(text="Рассылка новости")],
+        [KeyboardButton(text="Назад")],
+    ],
+    resize_keyboard=True,
+)

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,12 +1,13 @@
 import asyncio
 from aiogram import Bot, Dispatcher
 from aiogram.fsm.storage.memory import MemoryStorage
+from aiogram.client.default import DefaultBotProperties
 from .config import settings
 from .handlers import user, admin
 
 
 def create_bot() -> Bot:
-    return Bot(token=settings.token, parse_mode="HTML")
+    return Bot(token=settings.token, default=DefaultBotProperties(parse_mode="HTML"))
 
 
 def setup_dispatcher(bot: Bot) -> Dispatcher:

--- a/bot/states/forms.py
+++ b/bot/states/forms.py
@@ -3,3 +3,16 @@ from aiogram.fsm.state import StatesGroup, State
 class RequestForm(StatesGroup):
     service = State()
     description = State()
+
+
+class ExampleForm(StatesGroup):
+    file = State()
+    caption = State()
+
+
+class ServiceForm(StatesGroup):
+    name = State()
+
+
+class NewsForm(StatesGroup):
+    text = State()


### PR DESCRIPTION
## Summary
- fix bot initialization with DefaultBotProperties
- keep README instructions for running the bot
- add admin features for viewing requests and sending news
- store users, services and examples in SQLite
- handle 'My Services' in user menu

## Testing
- `poetry run python -m bot.main` *(fails: TokenValidationError)*
- `poetry run python -m bot` *(fails: TokenValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_686eaeae01dc8328982c85ad4d0bcb91