### PR TITLE
Improve service message handling

### DIFF
--- a/bot/db/dao.py
+++ b/bot/db/dao.py
@@ -51,6 +51,12 @@ class Database:
                         caption TEXT
                     )"""
             )
+            self.conn.execute(
+                """CREATE TABLE IF NOT EXISTS service_message (
+                        id INTEGER PRIMARY KEY CHECK (id = 1),
+                        message_id INTEGER
+                    )"""
+            )
 
     def add_request(
         self,
@@ -122,6 +128,21 @@ class Database:
                 "SELECT id, name, media, caption FROM services"
             ).fetchall()
 
+    def save_service_message(self, message_id: int) -> None:
+        with self.conn:
+            self.conn.execute("DELETE FROM service_message")
+            self.conn.execute(
+                "INSERT INTO service_message (id, message_id) VALUES (1, ?)",
+                (message_id,),
+            )
+
+    def get_service_message(self) -> int | None:
+        with self.conn:
+            row = self.conn.execute(
+                "SELECT message_id FROM service_message WHERE id = 1"
+            ).fetchone()
+            return row[0] if row else None
+
     def get_request(self, request_id: int) -> Tuple:
         with self.conn:
             return self.conn.execute(
@@ -130,5 +151,4 @@ class Database:
             ).fetchone()
 
     def delete_request(self, request_id: int) -> None:
-        with self.conn:
-            self.conn.execute("DELETE FROM requests WHERE id=?", (request_id,))
+        with self.conn:            self.conn.execute("DELETE FROM requests WHERE id=?", (request_id,))

--- a/bot/handlers/user.py
+++ b/bot/handlers/user.py
@@ -11,6 +11,18 @@ router = Router()
 
 db = Database(settings.db_path)
 
+
+async def send_services(msg: types.Message) -> bool:
+    """Send stored services message to the user."""
+    service_id = db.get_service_message()
+    if not service_id:
+        return False
+    try:
+        await msg.bot.copy_message(msg.chat.id, settings.admin_id, service_id)
+        return True
+    except Exception:
+        return False
+
 @router.message(CommandStart())
 async def start(msg: types.Message):
     db.add_user(msg.from_user.id, msg.from_user.username or "")
@@ -18,28 +30,18 @@ async def start(msg: types.Message):
         await msg.answer("Админ меню", reply_markup=admin_menu)
         return
     text = (
-        "  С помощью меню ниже оставьте заявку или свяжитесь со мной напрямую 👇"\
+        "  С помощью меню ниже оставьте заявку или свяжитесь со мной напрямую 👇"
     )
-    await msg.answer(text, reply_markup=main_menu)
+    await msg.answer(text)
+    await send_services(msg)
+    await msg.answer("Выберите опцию ниже", reply_markup=main_menu)
 
 
 @router.message(F.text == "Мои услуги")
 async def my_services(msg: types.Message):
-    services = db.get_services()
-    if not services:
-        await msg.answer("Пока нет услуг", reply_markup=back_kb)
-        return
-    for s in services:
-        media = s[2]
-        caption = s[3] or s[1] or ""
-        if media:
-            kind, fid = media.split(":", 1)
-            if kind == "photo":
-                await msg.answer_photo(fid, caption=caption)
-            else:
-                await msg.answer_video(fid, caption=caption)
-        else:
-            await msg.answer(caption)
+    sent = await send_services(msg)
+    if not sent:
+        await msg.answer("Пока нет услуг")
     await msg.answer("Нажмите 'Назад' для возврата", reply_markup=back_kb)
 
 

--- a/bot/states/forms.py
+++ b/bot/states/forms.py
@@ -7,9 +7,14 @@ class RequestForm(StatesGroup):
 
 
 class ServiceForm(StatesGroup):
+    """Legacy form for adding separate service entries."""
     file = State()
     caption = State()
 
 
-class NewsForm(StatesGroup):
+class ServicesMessageForm(StatesGroup):
+    """State for receiving a single message describing all services."""
     content = State()
+
+
+class NewsForm(StatesGroup):    content = State()


### PR DESCRIPTION
## Summary
- add table to store a single services message
- adjust admin command to save this message
- send the stored services message on /start and from the "Мои услуги" button

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686ee61c58008328b489e86bc61c2b13